### PR TITLE
feat: changed pitch visualisation to be more clear

### DIFF
--- a/src/components/Git.vue
+++ b/src/components/Git.vue
@@ -1,21 +1,20 @@
 <template>
-  <v-container class="fill-height">
+  <v-container class="fill-height w-50">
     <v-responsive class="d-flex align-center text-center fill-height">
-      <v-img
-        contain
-        height="150"
-        src="@/assets/git.png"
-      />
+      <v-img contain height="150" src="@/assets/git.png" />
       <!-- <h1 class="text-h2 font-weight-bold ma-2">Git</h1> -->
       <v-spacer></v-spacer>
       <div class="ma-2">
-        <v-btn color="#03045E" elevated href="https://github.com/TinTuna/BB3-Replay-Processor-Vuetify/"  target="_blank">Git Repository</v-btn>
+        <v-btn
+          color="#03045E"
+          elevated
+          href="https://github.com/TinTuna/BB3-Replay-Processor-Vuetify/"
+          target="_blank"
+          >Git Repository</v-btn
+        >
       </div>
-      
     </v-responsive>
   </v-container>
 </template>
 
-<script lang="ts" setup>
-
-</script>
+<script lang="ts" setup></script>

--- a/src/components/Match/MatchLog/PitchVisualization.vue
+++ b/src/components/Match/MatchLog/PitchVisualization.vue
@@ -4,6 +4,102 @@
       <v-row>
         <v-col cols="12">
           <div class="pitch-container">
+            <!-- SVG overlay for pitch markings (always visible) -->
+            <svg
+              class="pitch-markings-overlay"
+              viewBox="0 0 26 15"
+              preserveAspectRatio="none"
+            >
+              <!-- Solid white edge line -->
+              <line
+                x1="0"
+                y1="0"
+                x2="26"
+                y2="0"
+                stroke="white"
+                stroke-width="0.05"
+                stroke-linecap="round"
+              />
+              <line
+                x1="0"
+                y1="15"
+                x2="26"
+                y2="15"
+                stroke="white"
+                stroke-width="0.05"
+                stroke-linecap="round"
+              />
+              <line
+                x1="0"
+                y1="0"
+                x2="0"
+                y2="15"
+                stroke="white"
+                stroke-width="0.05"
+                stroke-linecap="round"
+              />
+              <line
+                x1="26"
+                y1="0"
+                x2="26"
+                y2="15"
+                stroke="white"
+                stroke-width="0.05"
+                stroke-linecap="round"
+              />
+              <!-- Solid white center line (line of scrimmage) -->
+              <line
+                x1="13"
+                y1="0"
+                x2="13"
+                y2="15"
+                stroke="white"
+                stroke-width="0.1"
+                stroke-linecap="round"
+              />
+              <!-- Solid white endzone line -->
+              <line
+                x1="1"
+                y1="0"
+                x2="1"
+                y2="15"
+                stroke="white"
+                stroke-width="0.05"
+                stroke-linecap="round"
+              />
+              <line
+                x1="25"
+                y1="0"
+                x2="25"
+                y2="15"
+                stroke="white"
+                stroke-width="0.05"
+                stroke-linecap="round"
+              />
+              <!-- Dashed white lines 4 cells from each edge -->
+              <line
+                x1="1"
+                y1="4"
+                x2="25"
+                y2="4"
+                stroke="white"
+                stroke-width="0.05"
+                stroke-dasharray="0.25"
+                stroke-dashoffset="0.125"
+                stroke-linecap="round"
+              />
+              <line
+                x1="1"
+                y1="11"
+                x2="25"
+                y2="11"
+                stroke="white"
+                stroke-width="0.05"
+                stroke-dasharray="0.25"
+                stroke-dashoffset="0.125"
+                stroke-linecap="round"
+              />
+            </svg>
             <!-- SVG overlay for movement path lines and push paths -->
             <svg
               v-if="
@@ -499,11 +595,21 @@ watch(
   width: 100%;
   overflow: auto;
   border: 2px solid #333;
-  background-image: url("@/assets/pitch.webp");
+  background-color: green;
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
   position: relative;
+}
+
+.pitch-markings-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1;
 }
 
 .movement-path-overlay {

--- a/src/components/Processor.vue
+++ b/src/components/Processor.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container class="fill-height">
+  <v-container class="fill-height w-75">
     <v-responsive class="d-flex text-center fill-height">
       <v-container class="pa-2" style="margin-top: 7vh">
         <v-card v-if="!loading && !loaded">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enhances pitch visualization with SVG field markings and a solid green background, plus minor layout width tweaks in Git and Processor views.
> 
> - **Pitch Visualization (`src/components/Match/MatchLog/PitchVisualization.vue`)**:
>   - **SVG Markings Overlay**: Adds always-visible SVG overlay with edge, endzone, center, and dashed wide-zone lines (`viewBox 26x15`).
>   - **Styling Updates**: Introduces styled path lines (`.movement-path-line`, `.push-path-line`) with shadows; new `.pitch-markings-overlay` layer; increases z-index layering.
>   - **Background**: Replaces image background with solid green (`background-color: green`).
> - **Layout Tweaks**:
>   - `src/components/Git.vue`: Container width set to `w-50`.
>   - `src/components/Processor.vue`: Container width set to `w-75`.}
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbc4b1cec39cd918547818fd38629b7fb4b83b81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->